### PR TITLE
Add custom allergen support

### DIFF
--- a/AllergenDetector/AllergenSelectionView.swift
+++ b/AllergenDetector/AllergenSelectionView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct AllergenSelectionView: View {
     @EnvironmentObject var settings: UserSettings
     @Environment(\.presentationMode) var presentationMode
+    @State private var newCustom = ""
 
     var body: some View {
         Form {
@@ -32,12 +33,32 @@ struct AllergenSelectionView: View {
                     }
                 }
             }
+
+            Section(header: Text("Custom Allergens")) {
+                ForEach(settings.customAllergens, id: \.self) { allergen in
+                    Text(allergen)
+                }
+                .onDelete { indexSet in
+                    settings.customAllergens.remove(atOffsets: indexSet)
+                }
+
+                HStack {
+                    TextField("Add allergen", text: $newCustom)
+                    Button("Add") {
+                        let trimmed = newCustom.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !trimmed.isEmpty else { return }
+                        settings.customAllergens.append(trimmed)
+                        newCustom = ""
+                    }
+                }
+            }
         }
         .navigationTitle("Allergens")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("Clear All") {
                     settings.selectedAllergens.removeAll()
+                    settings.customAllergens.removeAll()
                     presentationMode.wrappedValue.dismiss()
                 }
             }

--- a/AllergenDetector/ScannerViewModel.swift
+++ b/AllergenDetector/ScannerViewModel.swift
@@ -12,7 +12,7 @@ import SwiftUI
 class ScannerViewModel: ObservableObject {
     struct AllergenMatchDetail {
         let ingredient: String
-        let allergen: Allergen
+        let allergenName: String
         let explanation: String
     }
 
@@ -117,13 +117,21 @@ class ScannerViewModel: ObservableObject {
     @Published var showAlert = false
     @Published var matchDetails: [AllergenMatchDetail] = []
 
-    func handleBarcode(_ code: String, selectedAllergens: Set<Allergen>) {
+    func handleBarcode(
+        _ code: String,
+        selectedAllergens: Set<Allergen>,
+        customAllergens: [String]
+    ) {
         isLoading = true
         Task {
             do {
                 let product = try await ProductService.shared.fetchProduct(barcode: code)
                 scannedProduct = product
-                checkAllergens(product, selectedAllergens: selectedAllergens)
+                checkAllergens(
+                    product,
+                    selectedAllergens: selectedAllergens,
+                    customAllergens: customAllergens
+                )
             } catch _ as ProductError {
                 alertMessage = "Product not found in database. Please try another barcode."
                 showAlert = true
@@ -144,7 +152,11 @@ class ScannerViewModel: ObservableObject {
         }
     }
 
-    private func checkAllergens(_ product: Product, selectedAllergens: Set<Allergen>) {
+    private func checkAllergens(
+        _ product: Product,
+        selectedAllergens: Set<Allergen>,
+        customAllergens: [String]
+    ) {
         print("[DEBUG] Ingredients for \(product.productName):", product.ingredients)
         
         let intersection = Set(product.allergens).intersection(selectedAllergens)
@@ -165,9 +177,26 @@ class ScannerViewModel: ObservableObject {
             
             for (key, mapped) in Self.ingredientToAllergen {
                 if lowerIngredient.contains(key) && selectedAllergens.contains(mapped.allergen) {
-                    // Avoid duplicates for the same ingredient+allergen combination
-                    if !detailsArray.contains(where: { $0.ingredient == ingredient && $0.allergen == mapped.allergen }) {
-                        let detail = AllergenMatchDetail(ingredient: ingredient, allergen: mapped.allergen, explanation: mapped.explanation)
+                    if !detailsArray.contains(where: { $0.ingredient == ingredient && $0.allergenName == mapped.allergen.displayName }) {
+                        let detail = AllergenMatchDetail(
+                            ingredient: ingredient,
+                            allergenName: mapped.allergen.displayName,
+                            explanation: mapped.explanation
+                        )
+                        detailsArray.append(detail)
+                    }
+                }
+            }
+
+            for custom in customAllergens {
+                let customLower = custom.lowercased()
+                if lowerIngredient.contains(customLower) {
+                    if !detailsArray.contains(where: { $0.ingredient == ingredient && $0.allergenName.lowercased() == customLower }) {
+                        let detail = AllergenMatchDetail(
+                            ingredient: ingredient,
+                            allergenName: custom,
+                            explanation: "Custom allergen match"
+                        )
                         detailsArray.append(detail)
                     }
                 }
@@ -182,14 +211,16 @@ class ScannerViewModel: ObservableObject {
         if isSafe {
             alertMessage = "\(product.productName) is safe to eat!"
         } else {
-            let names = intersection.map { $0.displayName }.joined(separator: ", ")
+            let baseNames = intersection.map { $0.displayName }
+            let detailNames = detailsArray.map { $0.allergenName }
+            let names = Array(Set(baseNames + detailNames)).joined(separator: ", ")
             alertMessage = "Warning: contains \(names)."
         }
         
         if !detailsArray.isEmpty {
             alertMessage = (alertMessage ?? "") + "\nDetails:"
             for detail in detailsArray {
-                alertMessage! += "\n\(detail.ingredient): \(detail.allergen.displayName) - \(detail.explanation)"
+                alertMessage! += "\n\(detail.ingredient): \(detail.allergenName) - \(detail.explanation)"
             }
         }
         

--- a/AllergenDetector/UserSettings.swift
+++ b/AllergenDetector/UserSettings.swift
@@ -14,8 +14,14 @@ class UserSettings: ObservableObject {
             save()
         }
     }
+    @Published var customAllergens: [String] {
+        didSet {
+            saveCustom()
+        }
+    }
 
     private let defaultsKey = "SelectedAllergens"
+    private let customKey = "CustomAllergens"
 
     init() {
         if let data = UserDefaults.standard.data(forKey: defaultsKey),
@@ -24,11 +30,21 @@ class UserSettings: ObservableObject {
         } else {
             selectedAllergens = []
         }
+
+        if let array = UserDefaults.standard.stringArray(forKey: customKey) {
+            customAllergens = array
+        } else {
+            customAllergens = []
+        }
     }
 
     private func save() {
         if let data = try? JSONEncoder().encode(selectedAllergens) {
             UserDefaults.standard.set(data, forKey: defaultsKey)
         }
+    }
+
+    private func saveCustom() {
+        UserDefaults.standard.set(customAllergens, forKey: customKey)
     }
 }


### PR DESCRIPTION
## Summary
- allow saving user‐defined allergens in `UserSettings`
- enable creating and deleting custom allergens in the selection screen
- display custom allergen chips in the main view
- update scanning logic to check against custom allergens and show them in results
- pass custom allergens to the scanner view model

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68653a94948c8320b55d2fbfaaa24916