### PR TITLE
Add export option for scan history

### DIFF
--- a/AllergenDetector/HistoryService.swift
+++ b/AllergenDetector/HistoryService.swift
@@ -46,4 +46,30 @@ class HistoryService: ObservableObject {
             UserDefaults.standard.set(data, forKey: defaultsKey)
         }
     }
+
+    /// Exports the current history records to a temporary CSV file and returns its URL.
+    /// The CSV contains columns: barcode, product name, date scanned, and safety status.
+    func exportCSV() -> URL? {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+
+        var csvLines: [String] = ["Barcode,Product,Date,Safe"]
+        for record in records {
+            let dateString = formatter.string(from: record.dateScanned)
+            let safeString = record.isSafe ? "Yes" : "No"
+            let line = "\(record.barcode),\(record.productName),\(dateString),\(safeString)"
+            csvLines.append(line)
+        }
+
+        let csvString = csvLines.joined(separator: "\n")
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("ScanHistory.csv")
+        do {
+            try csvString.write(to: url, atomically: true, encoding: .utf8)
+            return url
+        } catch {
+            print("Failed to export CSV: \(error)")
+            return nil
+        }
+    }
 }

--- a/AllergenDetector/HistoryView.swift
+++ b/AllergenDetector/HistoryView.swift
@@ -8,6 +8,8 @@ import SwiftUI
 struct HistoryView: View {
     @ObservedObject private var history = HistoryService.shared
     @State private var editMode: EditMode = .inactive
+    @State private var exportURL: URL?
+    @State private var showingShare = false
 
     // DateFormatter for displaying scan timestamps
     private let dateFormatter: DateFormatter = {
@@ -55,8 +57,21 @@ struct HistoryView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 EditButton()
             }
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    exportURL = history.exportCSV()
+                    showingShare = exportURL != nil
+                } label: {
+                    Label("Export", systemImage: "square.and.arrow.up")
+                }
+            }
         }
         .environment(\.editMode, $editMode)
+        .sheet(isPresented: $showingShare, onDismiss: { exportURL = nil }) {
+            if let url = exportURL {
+                ShareSheet(activityItems: [url])
+            }
+        }
     }
 }
 

--- a/AllergenDetector/ShareSheet.swift
+++ b/AllergenDetector/ShareSheet.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+import UIKit
+
+struct ShareSheet: UIViewControllerRepresentable {
+    var activityItems: [Any]
+    var applicationActivities: [UIActivity]? = nil
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: applicationActivities)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # AllergenDetector
+
+AllergenDetector is an iOS application that scans product barcodes and warns users when allergens are detected. Users can select allergens to avoid, view a history of scanned items and, as of this version, export that history to a CSV file.
+
+## Exporting History
+
+Open the **History** screen and tap the **Export** button to share a CSV file of all recorded scans. The file includes the barcode, product name, date scanned, and whether the item was marked safe.


### PR DESCRIPTION
## Summary
- implement history export to CSV
- add ShareSheet for iOS share dialog
- expose Export button in history view
- flesh out README

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68653a9ae8fc832081701f161adaba34