### PR TITLE
Add per-allergen safety results

### DIFF
--- a/AllergenDetector/ContentView.swift
+++ b/AllergenDetector/ContentView.swift
@@ -64,7 +64,8 @@ struct ContentView: View {
             ProductCardView(
                 product: product,
                 selectedAllergens: settings.selectedAllergens,
-                matchDetails: viewModel.matchDetails
+                matchDetails: viewModel.matchDetails,
+                allergenStatuses: viewModel.allergenStatuses
             )
             .padding(.horizontal)
             .transition(.move(edge: .bottom).combined(with: .opacity))
@@ -189,10 +190,11 @@ struct ProductCardView: View {
     let product: Product
     let selectedAllergens: Set<Allergen>
     let matchDetails: [ScannerViewModel.AllergenMatchDetail]
+    let allergenStatuses: [Allergen: Bool]
 
     // Updated isSafe logic: product.allergens disjoint with selectedAllergens AND no matchDetails
     var isSafe: Bool {
-        Set(product.allergens).isDisjoint(with: selectedAllergens) && matchDetails.isEmpty
+        !allergenStatuses.values.contains(false)
     }
 
     var body: some View {
@@ -239,6 +241,21 @@ struct ProductCardView: View {
                                 Text("• \(allergen.displayName)")
                                     .font(.subheadline)
                             }
+                        }
+                    }
+                }
+
+                if !allergenStatuses.isEmpty {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Selected Allergen Results:")
+                            .font(.subheadline.weight(.semibold))
+                        ForEach(Array(selectedAllergens).sorted { $0.displayName < $1.displayName }) { allergen in
+                            HStack {
+                                Image(systemName: allergenStatuses[allergen] == true ? "checkmark.circle" : "xmark.octagon")
+                                    .foregroundColor(allergenStatuses[allergen] == true ? .green : .red)
+                                Text(allergen.displayName)
+                            }
+                            .font(.subheadline)
                         }
                     }
                 }

--- a/AllergenDetector/ScannerViewModel.swift
+++ b/AllergenDetector/ScannerViewModel.swift
@@ -116,6 +116,7 @@ class ScannerViewModel: ObservableObject {
     @Published var alertMessage: String?
     @Published var showAlert = false
     @Published var matchDetails: [AllergenMatchDetail] = []
+    @Published var allergenStatuses: [Allergen: Bool] = [:]
 
     func handleBarcode(_ code: String, selectedAllergens: Set<Allergen>) {
         isLoading = true
@@ -148,7 +149,7 @@ class ScannerViewModel: ObservableObject {
         print("[DEBUG] Ingredients for \(product.productName):", product.ingredients)
         
         let intersection = Set(product.allergens).intersection(selectedAllergens)
-        
+
         var detailsArray: [AllergenMatchDetail] = []
         
         for ingredient in product.ingredients {
@@ -174,20 +175,40 @@ class ScannerViewModel: ObservableObject {
             }
         }
         
-        var isSafe = intersection.isEmpty
-        if !detailsArray.isEmpty { isSafe = false }
-        
+        // Determine which allergens were flagged either from the product's
+        // reported allergens or via ingredient matching
+        let ingredientAllergens = Set(detailsArray.map { $0.allergen })
+        let flaggedAllergens = intersection.union(ingredientAllergens)
+
+        // Build status dictionary for each selected allergen
+        var statusDict: [Allergen: Bool] = [:]
+        for allergen in selectedAllergens {
+            statusDict[allergen] = !flaggedAllergens.contains(allergen)
+        }
+
+        let isSafe = !statusDict.values.contains(false)
+
         self.matchDetails = detailsArray
-        
+        self.allergenStatuses = statusDict
+
+        // Compose alert message summarizing safety
         if isSafe {
             alertMessage = "\(product.productName) is safe to eat!"
         } else {
-            let names = intersection.map { $0.displayName }.joined(separator: ", ")
-            alertMessage = "Warning: contains \(names)."
+            alertMessage = "\(product.productName) is NOT safe."
         }
-        
+
+        let statusLines = selectedAllergens
+            .sorted { $0.displayName < $1.displayName }
+            .map { allergen in
+                let safe = statusDict[allergen] ?? true
+                return "\(allergen.displayName): " + (safe ? "Safe" : "Not Safe")
+            }
+            .joined(separator: "\n")
+        alertMessage! += "\n" + statusLines
+
         if !detailsArray.isEmpty {
-            alertMessage = (alertMessage ?? "") + "\nDetails:"
+            alertMessage! += "\nDetails:"
             for detail in detailsArray {
                 alertMessage! += "\n\(detail.ingredient): \(detail.allergen.displayName) - \(detail.explanation)"
             }


### PR DESCRIPTION
## Summary
- show per-allergen safety in alert and product card
- track allergen statuses in `ScannerViewModel`
- display a check or X for each selected allergen

## Testing
- `swift --version`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687505d6f5c48320b5d3a2a6d937176d