### PR TITLE
Handle custom allergen matches when scanning products

### DIFF
--- a/AllergenDetector/AllergenSelectionView.swift
+++ b/AllergenDetector/AllergenSelectionView.swift
@@ -35,8 +35,8 @@ struct AllergenSelectionView: View {
             }
 
             Section(header: Text("Custom Allergens")) {
-                ForEach($settings.customAllergens) { $custom in
-                    Toggle(custom.name, isOn: $custom.isEnabled)
+                ForEach(settings.customAllergens) { allergen in
+                    Toggle(allergen.name, isOn: binding(for: allergen))
                 }
                 .onDelete { indexSet in
                     settings.customAllergens.remove(atOffsets: indexSet)
@@ -64,6 +64,13 @@ struct AllergenSelectionView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func binding(for allergen: CustomAllergen) -> Binding<Bool> {
+        guard let index = settings.customAllergens.firstIndex(of: allergen) else {
+            return .constant(allergen.isEnabled)
+        }
+        return $settings.customAllergens[index].isEnabled
     }
 }
 

--- a/AllergenDetector/ContentView.swift
+++ b/AllergenDetector/ContentView.swift
@@ -206,10 +206,12 @@ struct ProductCardView: View {
     let selectedAllergens: Set<Allergen>
     let matchDetails: [ScannerViewModel.AllergenMatchDetail]
     let allergenStatuses: [Allergen: Bool]
-
-    // Updated isSafe logic: product.allergens disjoint with selectedAllergens AND no matchDetails
+    
+    // Product is safe only if no selected allergens were flagged and no custom
+    // allergens were matched in the ingredients list.
     var isSafe: Bool {
-        !allergenStatuses.values.contains(false)
+        let hasCustomMatch = matchDetails.contains { $0.allergen == nil }
+        return !allergenStatuses.values.contains(false) && !hasCustomMatch
     }
 
     var body: some View {

--- a/AllergenDetector/ContentView.swift
+++ b/AllergenDetector/ContentView.swift
@@ -78,7 +78,8 @@ struct ContentView: View {
                 product: product,
                 selectedAllergens: settings.selectedAllergens,
                 matchDetails: viewModel.matchDetails,
-                allergenStatuses: viewModel.allergenStatuses
+                allergenStatuses: viewModel.allergenStatuses,
+                customAllergenStatuses: viewModel.customAllergenStatuses
             )
             .padding(.horizontal)
             .transition(.move(edge: .bottom).combined(with: .opacity))
@@ -206,11 +207,12 @@ struct ProductCardView: View {
     let selectedAllergens: Set<Allergen>
     let matchDetails: [ScannerViewModel.AllergenMatchDetail]
     let allergenStatuses: [Allergen: Bool]
+    let customAllergenStatuses: [String: Bool]
     
     // Product is safe only if no selected allergens were flagged and no custom
     // allergens were matched in the ingredients list.
     var isSafe: Bool {
-        let hasCustomMatch = matchDetails.contains { $0.allergen == nil }
+        let hasCustomMatch = customAllergenStatuses.values.contains(false)
         return !allergenStatuses.values.contains(false) && !hasCustomMatch
     }
 
@@ -267,7 +269,7 @@ struct ProductCardView: View {
                     }
                 }
 
-                if !allergenStatuses.isEmpty {
+                if !allergenStatuses.isEmpty || !customAllergenStatuses.isEmpty {
                     VStack(alignment: .leading, spacing: 4) {
                         Text("Selected Allergen Results:")
                             .font(.subheadline.weight(.semibold))
@@ -276,6 +278,15 @@ struct ProductCardView: View {
                                 Image(systemName: allergenStatuses[allergen] == true ? "checkmark.circle" : "xmark.octagon")
                                     .foregroundColor(allergenStatuses[allergen] == true ? .green : .red)
                                 Text(allergen.displayName)
+                            }
+                            .font(.subheadline)
+                        }
+                        ForEach(customAllergenStatuses.keys.sorted(), id: \.self) { name in
+                            HStack {
+                                let safe = customAllergenStatuses[name] == true
+                                Image(systemName: safe ? "checkmark.circle" : "xmark.octagon")
+                                    .foregroundColor(safe ? .green : .red)
+                                Text(name)
                             }
                             .font(.subheadline)
                         }

--- a/AllergenDetector/ContentView.swift
+++ b/AllergenDetector/ContentView.swift
@@ -198,6 +198,30 @@ struct ContentView: View {
                     pulse.toggle()
                 }
             }
+            .onChange(of: settings.selectedAllergens) { _ in
+                for key in Array(viewModel.allergenStatuses.keys) {
+                    if !settings.selectedAllergens.contains(key) {
+                        viewModel.allergenStatuses.removeValue(forKey: key)
+                    }
+                }
+                viewModel.matchDetails.removeAll { detail in
+                    if let allergen = detail.allergen {
+                        return !settings.selectedAllergens.contains(allergen)
+                    }
+                    return false
+                }
+            }
+            .onChange(of: settings.customAllergens) { _ in
+                let active = settings.activeCustomAllergenNames
+                for key in Array(viewModel.customAllergenStatuses.keys) {
+                    if !active.contains(key) {
+                        viewModel.customAllergenStatuses.removeValue(forKey: key)
+                    }
+                }
+                viewModel.matchDetails.removeAll { detail in
+                    detail.allergen == nil && !active.contains(detail.allergenName)
+                }
+            }
         }
     }
 }

--- a/AllergenDetector/ScannerViewModel.swift
+++ b/AllergenDetector/ScannerViewModel.swift
@@ -218,7 +218,10 @@ class ScannerViewModel: ObservableObject {
             statusDict[allergen] = !flaggedAllergens.contains(allergen)
         }
 
-        let isSafe = !statusDict.values.contains(false)
+        // If any custom allergen was matched, treat the product as unsafe even if
+        // all built-in allergens passed.
+        let hasCustomMatch = detailsArray.contains { $0.allergen == nil }
+        let isSafe = !statusDict.values.contains(false) && !hasCustomMatch
 
         self.matchDetails = detailsArray
         self.allergenStatuses = statusDict

--- a/AllergenDetector/ScannerViewModel.swift
+++ b/AllergenDetector/ScannerViewModel.swift
@@ -118,6 +118,7 @@ class ScannerViewModel: ObservableObject {
     @Published var showAlert = false
     @Published var matchDetails: [AllergenMatchDetail] = []
     @Published var allergenStatuses: [Allergen: Bool] = [:]
+    @Published var customAllergenStatuses: [String: Bool] = [:]
 
     func handleBarcode(
         _ code: String,
@@ -218,13 +219,23 @@ class ScannerViewModel: ObservableObject {
             statusDict[allergen] = !flaggedAllergens.contains(allergen)
         }
 
+        // Build status dictionary for each custom allergen
+        var customStatus: [String: Bool] = [:]
+        for custom in customAllergens {
+            let matched = detailsArray.contains {
+                $0.allergen == nil && $0.allergenName.lowercased() == custom.lowercased()
+            }
+            customStatus[custom] = !matched
+        }
+
         // If any custom allergen was matched, treat the product as unsafe even if
         // all built-in allergens passed.
-        let hasCustomMatch = detailsArray.contains { $0.allergen == nil }
+        let hasCustomMatch = customStatus.values.contains(false)
         let isSafe = !statusDict.values.contains(false) && !hasCustomMatch
 
         self.matchDetails = detailsArray
         self.allergenStatuses = statusDict
+        self.customAllergenStatuses = customStatus
 
         // Compose alert message summarizing safety
         if isSafe {
@@ -245,6 +256,17 @@ class ScannerViewModel: ObservableObject {
             }
             .joined(separator: "\n")
         alertMessage! += "\n" + statusLines
+
+        if !customStatus.isEmpty {
+            let customLines = customAllergens
+                .sorted { $0.lowercased() < $1.lowercased() }
+                .map { name in
+                    let safe = customStatus[name] ?? true
+                    return "\(name): " + (safe ? "Safe" : "Not Safe")
+                }
+                .joined(separator: "\n")
+            alertMessage! += "\n" + customLines
+        }
 
         if !detailsArray.isEmpty {
             alertMessage! += "\nDetails:"


### PR DESCRIPTION
## Summary
- treat custom allergen matches as unsafe in scan results
- ensure product card banner warns when custom allergens are detected

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6892b743d7348320bf0a35af820a96da