### PR TITLE
Handle barcodes lacking ingredient data

### DIFF
--- a/AllergenDetector/ContentView.swift
+++ b/AllergenDetector/ContentView.swift
@@ -73,7 +73,8 @@ struct ContentView: View {
                 selectedAllergens: settings.selectedAllergens,
                 matchDetails: viewModel.matchDetails,
                 allergenStatuses: viewModel.allergenStatuses,
-                customAllergenStatuses: viewModel.customAllergenStatuses
+                customAllergenStatuses: viewModel.customAllergenStatuses,
+                safetyStatus: viewModel.lastScanSafety ?? .unknown
             )
             .padding(.horizontal)
             .transition(.move(edge: .bottom).combined(with: .opacity))
@@ -196,21 +197,33 @@ struct ProductCardView: View {
     let matchDetails: [ScannerViewModel.AllergenMatchDetail]
     let allergenStatuses: [Allergen: Bool]
     let customAllergenStatuses: [String: Bool]
-    
-    // Product is safe only if no selected allergens were flagged and no custom
-    // allergens were matched in the ingredients list.
-    var isSafe: Bool {
-        let hasCustomMatch = customAllergenStatuses.values.contains(false)
-        return !allergenStatuses.values.contains(false) && !hasCustomMatch
-    }
+    let safetyStatus: SafetyStatus
 
     var body: some View {
-        VStack(spacing: 0) {
+        let icon: String
+        let title: String
+        let bannerColor: Color
+        switch safetyStatus {
+        case .safe:
+            icon = "checkmark.shield.fill"
+            title = "Safe to Eat"
+            bannerColor = Color(.systemGreen)
+        case .unsafe:
+            icon = "exclamationmark.triangle.fill"
+            title = "Warning!"
+            bannerColor = Color(.systemRed)
+        case .unknown:
+            icon = "questionmark.diamond.fill"
+            title = "Unknown Safety"
+            bannerColor = Color(.systemOrange)
+        }
+
+        return VStack(spacing: 0) {
             // HEADER BANNER - shows safety based on combined logic of allergens and matchDetails
             HStack {
-                Image(systemName: isSafe ? "checkmark.shield.fill" : "exclamationmark.triangle.fill")
+                Image(systemName: icon)
                     .foregroundColor(.white)
-                Text(isSafe ? "Safe to Eat" : "Warning!")
+                Text(title)
                     .font(.headline)
                     .foregroundColor(.white)
                 Spacer()
@@ -220,7 +233,7 @@ struct ProductCardView: View {
             }
             .padding(.horizontal)
             .padding(.vertical, 12)
-            .background(isSafe ? Color(.systemGreen) : Color(.systemRed))
+            .background(bannerColor)
 
             // MAIN CONTENT
             VStack(alignment: .leading, spacing: 8) {

--- a/AllergenDetector/HistoryService.swift
+++ b/AllergenDetector/HistoryService.swift
@@ -56,7 +56,15 @@ class HistoryService: ObservableObject {
         var lines: [String] = []
         for record in records {
             let dateString = formatter.string(from: record.dateScanned)
-            let safeString = record.isSafe ? "Safe" : "Unsafe"
+            let safeString: String
+            switch record.safety {
+            case .safe:
+                safeString = "Safe"
+            case .unsafe:
+                safeString = "Unsafe"
+            case .unknown:
+                safeString = "Unknown"
+            }
             let line = "\(record.barcode) - \(record.productName) - \(dateString) - \(safeString)"
             lines.append(line)
         }

--- a/AllergenDetector/HistoryView.swift
+++ b/AllergenDetector/HistoryView.swift
@@ -45,8 +45,20 @@ struct HistoryView: View {
                                 .foregroundColor(.secondary)
                         }
                         Spacer()
-                        Image(systemName: record.isSafe ? "checkmark.seal.fill" : "xmark.shield.fill")
-                            .foregroundColor(record.isSafe ? .green : .red)
+                        let (icon, color): (String, Color)
+                        switch record.safety {
+                        case .safe:
+                            icon = "checkmark.seal.fill"
+                            color = .green
+                        case .unsafe:
+                            icon = "xmark.shield.fill"
+                            color = .red
+                        case .unknown:
+                            icon = "questionmark.diamond.fill"
+                            color = .yellow
+                        }
+                        Image(systemName: icon)
+                            .foregroundColor(color)
                     }
                     .padding(.vertical, 4)
                 }

--- a/AllergenDetector/ScanRecord.swift
+++ b/AllergenDetector/ScanRecord.swift
@@ -5,11 +5,18 @@
 
 import Foundation
 
+/// Indicates whether a scanned product is safe to consume.
+enum SafetyStatus: String, Codable {
+    case safe
+    case unsafe
+    case unknown
+}
+
 /// Represents a single scan event saved in history.
 struct ScanRecord: Identifiable, Codable {
     let id: UUID
     let barcode: String
     let productName: String
     let dateScanned: Date
-    let isSafe: Bool
+    let safety: SafetyStatus
 }

--- a/AllergenDetector/ScannerViewModel.swift
+++ b/AllergenDetector/ScannerViewModel.swift
@@ -130,11 +130,19 @@ class ScannerViewModel: ObservableObject {
             do {
                 let product = try await ProductService.shared.fetchProduct(barcode: code)
                 scannedProduct = product
-                checkAllergens(
-                    product,
-                    selectedAllergens: selectedAllergens,
-                    customAllergens: customAllergens
-                )
+
+                if product.ingredients.isEmpty {
+                    alertMessage = "\(product.productName) does not list any ingredients. Unable to check for allergens."
+                    showAlert = true
+                    let generator = UINotificationFeedbackGenerator()
+                    generator.notificationOccurred(.warning)
+                } else {
+                    checkAllergens(
+                        product,
+                        selectedAllergens: selectedAllergens,
+                        customAllergens: customAllergens
+                    )
+                }
             } catch _ as ProductError {
                 alertMessage = "Product not found in database. Please try another barcode."
                 showAlert = true


### PR DESCRIPTION
## Summary
- Warn user when a scanned barcode's product lacks ingredient information

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689690fa7a248320b0b97dc5951d3d38