### PR TITLE
Fix allergen status not updating after preference changes

### DIFF
--- a/AllergenDetector/ContentView.swift
+++ b/AllergenDetector/ContentView.swift
@@ -84,22 +84,6 @@ struct ContentView: View {
         }
     }
 
-    private func handleSelectedAllergensChange() {
-        for key in Array(viewModel.allergenStatuses.keys) {
-            if !settings.selectedAllergens.contains(key) {
-                viewModel.allergenStatuses.removeValue(forKey: key)
-            }
-        }
-        viewModel.matchDetails.removeAll { detail in
-            let contains: Bool
-            if let allergen = detail.allergen {
-                contains = !settings.selectedAllergens.contains(allergen)
-            } else {
-                contains = false
-            }
-            return contains
-        }
-    }
 
     var body: some View {
         NavigationView {
@@ -160,17 +144,17 @@ struct ContentView: View {
                     pulse.toggle()
                 }
             }
-            .onChange(of: settings.selectedAllergens, handleSelectedAllergensChange)
-            .onChange(of: settings.customAllergens) {
-                let active = settings.activeCustomAllergenNames
-                for key in Array(viewModel.customAllergenStatuses.keys) {
-                    if !active.contains(key) {
-                        viewModel.customAllergenStatuses.removeValue(forKey: key)
-                    }
-                }
-                viewModel.matchDetails.removeAll { detail in
-                    detail.allergen == nil && !active.contains(detail.allergenName)
-                }
+            .onChange(of: settings.selectedAllergens) { _ in
+                viewModel.reevaluateCurrentProduct(
+                    selectedAllergens: settings.selectedAllergens,
+                    customAllergens: settings.activeCustomAllergenNames
+                )
+            }
+            .onChange(of: settings.customAllergens) { _ in
+                viewModel.reevaluateCurrentProduct(
+                    selectedAllergens: settings.selectedAllergens,
+                    customAllergens: settings.activeCustomAllergenNames
+                )
             }
         }
     }

--- a/AllergenDetector/ScannerViewModel.swift
+++ b/AllergenDetector/ScannerViewModel.swift
@@ -125,6 +125,18 @@ class ScannerViewModel: ObservableObject {
     @Published var customAllergenStatuses: [String: Bool] = [:]
     @Published var lastScanSafety: SafetyStatus?
 
+    func reevaluateCurrentProduct(
+        selectedAllergens: Set<Allergen>,
+        customAllergens: [String]
+    ) {
+        guard let product = scannedProduct else { return }
+        checkAllergens(
+            product,
+            selectedAllergens: selectedAllergens,
+            customAllergens: customAllergens
+        )
+    }
+
     func handleBarcode(
         _ code: String,
         selectedAllergens: Set<Allergen>,


### PR DESCRIPTION
## Summary
- Recalculate allergen statuses for the last scanned product whenever the user updates allergen selections
- Update ContentView change handlers to trigger status recalculation

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689f7616a9b8832091e28b4d76b45d2d