### PR TITLE
Add onboarding flow with safety warnings

### DIFF
--- a/AllergenDetector/AllergenDetectorApp.swift
+++ b/AllergenDetector/AllergenDetectorApp.swift
@@ -12,8 +12,13 @@ struct AllergenDetectorApp: App {
     @StateObject private var settings = UserSettings()
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .environmentObject(settings)
+            if settings.hasCompletedOnboarding {
+                ContentView()
+                    .environmentObject(settings)
+            } else {
+                OnboardingView()
+                    .environmentObject(settings)
+            }
         }
     }
 }

--- a/AllergenDetector/ContentView.swift
+++ b/AllergenDetector/ContentView.swift
@@ -75,6 +75,14 @@ struct ContentView: View {
         }
     }
 
+    private var safetyDisclaimer: some View {
+        Text("Always verify ingredients on the actual product if you have a life-threatening allergy.")
+            .font(.footnote)
+            .foregroundColor(.secondary)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal)
+    }
+
     private func startScanFeedback() {
         scanStatusMessage = "Align the barcode within the frame"
         DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
@@ -99,8 +107,11 @@ struct ContentView: View {
                 
                 // MARK: Last Scanned Product Card (spring‐animate its appearance)
                 scannedProductCardView
-                
-                
+                if viewModel.scannedProduct != nil {
+                    safetyDisclaimer
+                }
+
+
                 Spacer()
                 scanButtonView
                 Spacer()

--- a/AllergenDetector/OnboardingView.swift
+++ b/AllergenDetector/OnboardingView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct OnboardingView: View {
+    @EnvironmentObject var settings: UserSettings
+    @State private var selection = 0
+
+    var body: some View {
+        TabView(selection: $selection) {
+            VStack(spacing: 20) {
+                Spacer()
+                Text("Welcome to Allergen Detector")
+                    .font(.largeTitle)
+                    .bold()
+                    .multilineTextAlignment(.center)
+                Text("Scan barcodes and quickly check products for allergens you want to avoid.")
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+                Spacer()
+                Button("Next") { selection = 1 }
+                    .buttonStyle(.borderedProminent)
+                    .padding()
+            }
+            .tag(0)
+
+            VStack(spacing: 20) {
+                Spacer()
+                Text("Select Your Allergens")
+                    .font(.largeTitle)
+                    .bold()
+                Text("Customize your allergen list so the app can flag ingredients that matter to you.")
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+                Spacer()
+                Button("Next") { selection = 2 }
+                    .buttonStyle(.borderedProminent)
+                    .padding()
+            }
+            .tag(1)
+
+            VStack(spacing: 20) {
+                Spacer()
+                Text("Stay Safe")
+                    .font(.largeTitle)
+                    .bold()
+                Text("If you have a life‑threatening allergy, always double‑check the ingredient list on the product even when the app says it's safe.")
+                    .multilineTextAlignment(.center)
+                    .padding()
+                Spacer()
+                Button("Get Started") {
+                    settings.hasCompletedOnboarding = true
+                }
+                .buttonStyle(.borderedProminent)
+                .padding()
+            }
+            .tag(2)
+        }
+        .tabViewStyle(.page)
+    }
+}
+
+#Preview {
+    OnboardingView()
+        .environmentObject(UserSettings())
+}

--- a/AllergenDetector/UserSettings.swift
+++ b/AllergenDetector/UserSettings.swift
@@ -19,9 +19,15 @@ class UserSettings: ObservableObject {
             saveCustom()
         }
     }
+    @Published var hasCompletedOnboarding: Bool {
+        didSet {
+            saveOnboarding()
+        }
+    }
 
     private let defaultsKey = "SelectedAllergens"
     private let customKey = "CustomAllergens"
+    private let onboardingKey = "HasCompletedOnboarding"
 
     init() {
         if let data = UserDefaults.standard.data(forKey: defaultsKey),
@@ -37,6 +43,8 @@ class UserSettings: ObservableObject {
         } else {
             customAllergens = []
         }
+
+        hasCompletedOnboarding = UserDefaults.standard.bool(forKey: onboardingKey)
     }
 
     private func save() {
@@ -49,6 +57,10 @@ class UserSettings: ObservableObject {
         if let data = try? JSONEncoder().encode(customAllergens) {
             UserDefaults.standard.set(data, forKey: customKey)
         }
+    }
+
+    private func saveOnboarding() {
+        UserDefaults.standard.set(hasCompletedOnboarding, forKey: onboardingKey)
     }
 
     var activeCustomAllergenNames: [String] {


### PR DESCRIPTION
## Summary
- Introduce multi-page onboarding flow guiding new users and warning to verify ingredient lists for severe allergies
- Persist onboarding completion in user settings and show onboarding on first launch
- Display in-app safety disclaimer after scans to remind users to double-check packaging

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b8303dfc832091e8f82dfdd23a35